### PR TITLE
Adding support for asciidoc

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Unofficial Grammarly extension.
 
 - Issue highlighting with hover description.
 - Replacement and synonym suggestions.
-- Checks plaintext and markdown.
+- Checks plaintext, markdown, and asciidoc.
 
 ## Extension Settings
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -43,6 +43,14 @@ export async function activate(context: vscode.ExtensionContext) {
         scheme: 'untitled',
         language: 'latex',
       },
+      {
+        scheme: 'file',
+        language: 'asciidoc',
+      },
+      {
+        scheme: 'untitled',
+        language: 'asciidoc',
+      },
     ],
     synchronize: {
       configurationSection: 'grammarly',


### PR DESCRIPTION
AsciiDoc is another documentation format similar to markdown. It
is popular in documentation circles.