### PR TITLE
Mdx Support

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "activationEvents": [
     "onLanguage:plaintext",
     "onLanguage:markdown",
-    "onLanguage:markdown react",
+    "onLanguage:mdx",
     "onCommand:grammarly.check"
   ],
   "contributes": {

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   "activationEvents": [
     "onLanguage:plaintext",
     "onLanguage:markdown",
+    "onLanguage:markdown react",
     "onCommand:grammarly.check"
   ],
   "contributes": {

--- a/src/client/options.ts
+++ b/src/client/options.ts
@@ -23,7 +23,7 @@ export function getLanguageServerOptions(module: string): ServerOptions {
   }
 }
 
-export const LANGUAGES = ['plaintext', 'markdown', 'markdown react', 'latex', 'restructuredtext', 'git-commit', 'git-rebase']
+export const LANGUAGES = ['plaintext', 'markdown', 'mdx', 'latex', 'restructuredtext', 'git-commit', 'git-rebase']
 export function getLanguageClientOptions(): LanguageClientOptions {
   return {
     documentSelector: generateDocumentSelectors(LANGUAGES),

--- a/src/client/options.ts
+++ b/src/client/options.ts
@@ -23,7 +23,7 @@ export function getLanguageServerOptions(module: string): ServerOptions {
   }
 }
 
-export const LANGUAGES = ['plaintext', 'markdown', 'latex', 'restructuredtext', 'git-commit', 'git-rebase']
+export const LANGUAGES = ['plaintext', 'markdown', 'markdown react', 'latex', 'restructuredtext', 'git-commit', 'git-rebase']
 export function getLanguageClientOptions(): LanguageClientOptions {
   return {
     documentSelector: generateDocumentSelectors(LANGUAGES),

--- a/src/protocol/index.ts
+++ b/src/protocol/index.ts
@@ -37,7 +37,7 @@ export function createHandler<T extends APILike>(handlers: T): LanguageServer {
 
 export type DictionaryType = 'grammarly' | 'workspace' | 'folder' | 'user'
 
-export interface DocumentStatitics {
+export interface DocumentStatistics {
   performance: {
     score: number
   }
@@ -75,5 +75,5 @@ export interface GrammarlyServerAPI {
   ): Promise<void>
 
   getSummary(resource: string): Promise<DocumentSummary>
-  getStatistics(resource: string): Promise<DocumentStatitics>
+  getStatistics(resource: string): Promise<DocumentStatistics>
 }

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -43,6 +43,9 @@ export const DEFAULT_SETTINGS: GrammarlySettings = {
     '[markdown]': {
       ignore: ['code'],
     },
+    '[markdown react]': {
+      ignore: ['code'],
+    },
   },
 
   /** Grammarly Config */

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -43,7 +43,7 @@ export const DEFAULT_SETTINGS: GrammarlySettings = {
     '[markdown]': {
       ignore: ['code'],
     },
-    '[markdown react]': {
+    '[mdx]': {
       ignore: ['code'],
     },
   },


### PR DESCRIPTION
Closes #26 

## Overview

This PR provides support for MDX (`markdown react`). It does not enable the support of customizable extensions, as mentioned in the issue. I imagine that would be better suited for a different, additional PR.

As there were no automated tests already in place, I manually tested and verified the change.