### PR TITLE
Add Asciidoc support

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "onLanguage:plaintext",
     "onLanguage:markdown",
     "onLanguage:mdx",
+    "onLanguage:asciidoc",
     "onCommand:grammarly.check"
   ],
   "contributes": {

--- a/src/client/options.ts
+++ b/src/client/options.ts
@@ -23,7 +23,7 @@ export function getLanguageServerOptions(module: string): ServerOptions {
   }
 }
 
-export const LANGUAGES = ['plaintext', 'markdown', 'mdx', 'latex', 'restructuredtext', 'git-commit', 'git-rebase']
+export const LANGUAGES = ['plaintext', 'markdown', 'mdx', 'asciidoc', 'latex', 'restructuredtext', 'git-commit', 'git-rebase']
 export function getLanguageClientOptions(): LanguageClientOptions {
   return {
     documentSelector: generateDocumentSelectors(LANGUAGES),

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -46,6 +46,9 @@ export const DEFAULT_SETTINGS: GrammarlySettings = {
     '[mdx]': {
       ignore: ['code'],
     },
+    '[asciidoc]': {
+      ignore: ['code'],
+    },
   },
 
   /** Grammarly Config */


### PR DESCRIPTION
Add Asciidoc support.
I follow the instruction here https://github.com/znck/grammarly/issues/28