### PR TITLE
#140 Fix unknown alert category causing an error in severity selection

### DIFF
--- a/src/server/helpers.ts
+++ b/src/server/helpers.ts
@@ -127,7 +127,17 @@ export function createDiagnostic(
   alert: Grammarly.Alert,
   severityMap: Record<string, DiagnosticSeverity>
 ) {
-  const severity = severityMap[alert.category] || severityMap['_default'];
+  let severity;
+  if (severityMap.hasOwnProperty('_default')) {
+    severity = severityMap['_default'];
+  }
+  else if (severityMap.hasOwnProperty(alert.category)) {
+    severity = severityMap[alert.category];
+  }
+  else {
+    severity = DiagnosticSeverity.Error;
+  }
+
   const diagnostic: Diagnostic = {
     severity,
     message: (alert.title || '').replace(/<\/?[^>]+(>|$)/g, ''),


### PR DESCRIPTION
See the following issue: https://github.com/znck/grammarly/issues/140

The cause was that `severityMap[alert.category]` causes an error and defaults to 'Hint' when the alert category is unknown. The default category is then not checked in this scenario.

In this fix, if the default severity is selected, it will override all other severities.