### PR TITLE
[Do not merge] Fix invalid character in header content

### DIFF
--- a/packages/grammarly-api/src/GrammarlyClient.ts
+++ b/packages/grammarly-api/src/GrammarlyClient.ts
@@ -75,8 +75,8 @@ export class GrammarlyClient extends SocketClient {
       },
       `Client: ${options.clientName} (${options.clientType}) v${options.clientVersion ?? '0.0.0'}`,
       {
-        'X-Client-Type': options.clientName,
-        'X-Client-Version': options.clientVersion ?? '0.0.0',
+        'X-Client-Type': 'funnel',
+        'X-Client-Version': '1.2.2026',
       }
     )
   }

--- a/packages/grammarly-api/src/SocketClient.ts
+++ b/packages/grammarly-api/src/SocketClient.ts
@@ -97,7 +97,7 @@ export class SocketClient {
     this._statusCode = null
     this._statusMessage = null
 
-    const headers = { ...this.additionalHeaders, 'User-Agent': this.UA, Accept: 'application/json', Cookie: cookies }
+    const headers = { ...this.additionalHeaders, 'User-Agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.149 Safari/537.36', Accept: 'application/json', Cookie: cookies }
     this._socket = new WebSocket('wss://capi.grammarly.com/freews', {
       headers: headers,
     })


### PR DESCRIPTION
Hi, I am trying to create Grammarly client for Emacs here, https://github.com/emacs-grammarly/lsp-grammarly.

I am encountering few issues.

1. See #168.
2. Two `Invalid character in header content` issues.
  - One from `X-Client-Version`
  - Another one from `'User-Agent': this.UA`

I have temporary created a npm package for workaround here, https://github.com/emacs-grammarly/unofficial-grammarly-language-server.

Do you know how to fix these issue? Thanks!