### PR TITLE
Add Org files to the list of supported languages

### DIFF
--- a/packages/grammarly-language-client/src/options.ts
+++ b/packages/grammarly-language-client/src/options.ts
@@ -32,6 +32,7 @@ export const LANGUAGES = [
   'mdx',
   'plaintext',
   'restructuredtext',
+  'org',
 ]
 
 export function getLanguageClientOptions(): LanguageClientOptions {


### PR DESCRIPTION
This PR adds support to Org files.

This solution was originally reported on #126. 