### PR TITLE
Support for R Markdown

### DIFF
--- a/extension/package.json
+++ b/extension/package.json
@@ -20,6 +20,7 @@
     "onUri",
     "onLanguage:plaintext",
     "onLanguage:markdown",
+    "onLanguage:rmd",
     "onLanguage:mdx",
     "onCommand:grammarly.login",
     "onCommand:grammarly.logout",

--- a/extension/src/settings.ts
+++ b/extension/src/settings.ts
@@ -56,6 +56,9 @@ export const DEFAULT: GrammarlySettings = {
     '[markdown]': {
       ignore: ['code'],
     },
+    '[rmd]': {
+      ignore: ['code'],
+    },
     '[mdx]': {
       ignore: ['code'],
     },

--- a/packages/grammarly-language-client/src/options.ts
+++ b/packages/grammarly-language-client/src/options.ts
@@ -29,6 +29,7 @@ export const LANGUAGES = [
   'json',
   'latex',
   'markdown',
+  'rmd',
   'mdx',
   'plaintext',
   'restructuredtext',


### PR DESCRIPTION
I was not able to build this extension as the build process is not well documented. But I made the following edits to the distributed VSCode extension and it works well. 

For folks who want Rmd support before this gets merged, you can use my modified build here:

[znck.grammarly-0.14.0.zip](https://github.com/znck/grammarly/files/7786872/znck.grammarly-0.14.0.zip)

Unzip it in `~/.vscode/extensions`.