### PR TITLE
feat: publish extension to Open VSX Registry

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -235,6 +235,11 @@ jobs:
           VSCODE_MARKETPLACE_TOKEN: ${{ secrets.VSCE_TOKEN }}
           OVSX_REGISTRY_TOKEN: ${{ secrets.OVSX_REGISTRY_TOKEN }}
         continue-on-error: true
+      - name: Publish to Open VSX Registry
+        run: |
+          pnpm recursive --filter ./extension run build
+          yes | npx ovsx publish ./extension/grammarly.vsix -p ${{ secrets.OPEN_VSX_TOKEN }}
+        continue-on-error: true
       - name: Publish Packages
         run: |
           echo '//registry.npmjs.org/:_authToken=${NPM_TOKEN}' > .npmrc


### PR DESCRIPTION
## Description
This PR is to Publish this VS Code Extension to [Open VSX Regsitry](https://open-vsx.org/).

## Action Item

This Addition Requires the `OPEN_VSX_TOKEN` to be added in Action Secrets. You can [get it from here](https://open-vsx.org/user-settings/tokens)

## Fixes

It Would add support to using amazing extensions like this on [Gitpod](https://gitpod.io/)
Relevant [Discussion on Twitter](https://twitter.com/maiertech/status/1558740222711459842?s=20&t=4rm4rJ1cGhWpzXwldqr2Ww)


## Recommended Reading

- [Publishing Extensions to Open VSX Registry](https://github.com/eclipse/openvsx/wiki/Publishing-Extensions)