### PR TITLE
Update README.md to clarify enabling languages

### DIFF
--- a/extension/README.md
+++ b/extension/README.md
@@ -35,6 +35,10 @@ Configure dialect, document domain, and which check to include in settings.
 - plaintext
 - markdown (work in progress) — [CommonMark](https://commonmark.org/)
 - html (work in progress)
+- Many more you can enable by opening Grammarly > Files > Include in settings:
+
+![image](https://user-images.githubusercontent.com/120114860/208191020-702c5053-7a97-469e-bde1-bdada021ed90.png)
+
 
 ## Troubleshooting
 


### PR DESCRIPTION
While the getting started guide notes how to configure which files should be checked with Grammarly, it does not clarify that other languages are supported besides the three listed under "Supported Languages."

Proposing adding a one-liner that states that many more languages are available to use Grammarly with, along with a screenshot of a different language like Asciidoc that is not mentioned in the "Supported Languages" section.