### PR TITLE
Adds command to open your personal dictionary

### DIFF
--- a/extension/README.md
+++ b/extension/README.md
@@ -23,6 +23,7 @@ You may use `grammarly.files.exclude` to ignore specific files.
 
 Run `grammarly.login` or **Grammarly: Login / Connect your account** command to connect your Grammarly account.
 Run `grammarly.logout` or **Grammarly: Log out** to disconnect your account.
+Run `grammarly.dictionary` or **Grammarly: Open Dictionary** to open grammarly.com to your personal dictionary.
 
 ## Configuration
 

--- a/extension/package.json
+++ b/extension/package.json
@@ -29,6 +29,7 @@
     "onCommand:grammarly.check",
     "onCommand:grammarly.login",
     "onCommand:grammarly.logout",
+    "onCommand:grammarly.dictionary",
     "onLanguage:plaintext",
     "onLanguage:markdown",
     "onLanguage:html"
@@ -772,6 +773,13 @@
         "command": "grammarly.logout",
         "icon": "$(log-out)",
         "enablement": "grammarly.isUserAccountConnected"
+      },
+      {
+        "title": "Open Dictionary",
+        "category": "Grammarly",
+        "command": "grammarly.dictionary",
+        "icon": "$(book)",
+        "enablement": "!grammarly.isRunning || !grammarly.isUserAccountConnected"
       },
       {
         "title": "Restart language server",

--- a/extension/src/GrammarlyClient.ts
+++ b/extension/src/GrammarlyClient.ts
@@ -206,6 +206,13 @@ export class GrammarlyClient implements Registerable {
         await this.client.protocol.logout()
         await window.showInformationMessage('Logged out.')
       }),
+      commands.registerCommand('grammarly.dictionary', async () => {
+        const dictionaryExternalURL = 'https://account.grammarly.com/customize';
+
+        if (!(await env.openExternal(dictionaryExternalURL))) {
+          await window.showErrorMessage('Failed to open dictionary.')
+        }
+      }),
       { dispose: () => this.session?.dispose() },
     )
   }


### PR DESCRIPTION
Adds a convenient function to open your browser to your grammarly dictionary.

Cloned aspects of the grammarly.login function, as I haven't written too many VScode extensions.