### PR TITLE
fix grammar of extension description

### DIFF
--- a/extension/package.json
+++ b/extension/package.json
@@ -3,7 +3,7 @@
   "name": "grammarly",
   "publisher": "znck",
   "displayName": "Grammarly",
-  "description": "A grammar checking for Visual Studio Code using Grammarly.",
+  "description": "A grammar checking extension for Visual Studio Code using Grammarly.",
   "version": "0.24.0",
   "icon": "assets/logo.png",
   "preview": true,


### PR DESCRIPTION
Noticed this in the extension directory, appreciated the irony, but figured I'd fix it while top of mind.

I suppose it could also be:

> Grammar checking for VS Code Studio using Grammarly.